### PR TITLE
Improve exchange price handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains a Python script for simulating cryptocurrency arbitrage
 - **Trade simulation**: Simulates buy and sell trades between exchanges to evaluate potential profits.
 - **Portfolio rebalancing**: Maintains balanced BTC holdings across exchanges to optimize arbitrage opportunities.
 - **Customizable parameters**: Allows adjustment of fees, trade volume, and simulation settings.
+- **Robust error handling**: Skips unavailable exchange data without interrupting the simulation.
 
 ---
 


### PR DESCRIPTION
## Summary
- handle API errors gracefully and skip failing exchanges
- parse prices from more exchanges including OKX, KuCoin, Gate.io, Bitstamp, Gemini, Poloniex and Crypto.com
- ignore missing prices when calculating total assets
- document new error handling feature

## Testing
- `python -c "import importlib.util; spec=importlib.util.spec_from_file_location('ca','crypt-arbitrage.py'); ca=importlib.util.module_from_spec(spec); spec.loader.exec_module(ca); ca.simulate_trades(num_trades=1, interval=0)"`

------
https://chatgpt.com/codex/tasks/task_e_687e22e92938832f953614eebebd650e